### PR TITLE
fix bug in assignment of `numCluster`

### DIFF
--- a/Matlab/expectation.m
+++ b/Matlab/expectation.m
@@ -9,7 +9,8 @@ Output:
     X: the dataset with updated labels
 %}
 
-[numPoints, numClusters] = size(X);
+[numPoints, ~] = size(X);
+numClusters = max(X(:,3));
 
 % define a function to calculate the distance between a set of points and a
 % mean

--- a/Matlab/maximization.m
+++ b/Matlab/maximization.m
@@ -9,7 +9,8 @@ Output:
     Mu: updated centers
 %}
 
-[~, numClusters] = size(X);
+numCluster = max(X(:,3));
+
 Mu = zeros(numClusters, 2);
 for jj = 1:numClusters
     idx = X(:,3) == jj;

--- a/Matlab/maximization.m
+++ b/Matlab/maximization.m
@@ -9,7 +9,7 @@ Output:
     Mu: updated centers
 %}
 
-numCluster = max(X(:,3));
+numClusters = max(X(:,3));
 
 Mu = zeros(numClusters, 2);
 for jj = 1:numClusters


### PR DESCRIPTION
Greetings, I'm currently learning from your code, and I discovered a bug.
In `expectation.m` and `maximization.m`, the variable `numCluster` was set as the second value of `size(X)`.

Actually, the second value of `size(X)` is always 3, no matter what the real value of `numCluster` is.
I think the 3rd column of `X` is the cluster index (ranging from 1 to `numCluster`), so I changed it into `numClusters = max(X(:,3));`, and it looks good.

I didn't find it until I changed the `numCluster` from 3 to other values and got a bug report :joy: